### PR TITLE
Add support for Luma 13.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ CIA_OUT_FOLDER  := $(OUT_FOLDER)/cia_out
 3DS_OUT	        := 3ds
 CIA_OUT         := cias
 
-LUMA_OUT	    := luma/titles
+LUMA_OUT		:= luma/titles
+LUMA_SYSMODULES_OUT	:= luma/sysmodules
 
 FRIENDS_TITLE_ID	:= 0004013000003202
 ACT_TITLE_ID	:= 0004013000003802
@@ -17,9 +18,9 @@ MIIVERSE_ID_JPN     := 000400300000BC02
 MIIVERSE_ID_USA     := 000400300000BD02
 MIIVERSE_ID_EUR     := 000400300000BE02
 
-FRIENDS_OUT     := $(LUMA_OUT)/$(FRIENDS_TITLE_ID)
-ACT_OUT         := $(LUMA_OUT)/$(ACT_TITLE_ID)
-SSL_OUT         := $(LUMA_OUT)/$(SSL_TITLE_ID)
+FRIENDS_OUT     := $(LUMA_SYSMODULES_OUT)/$(FRIENDS_TITLE_ID).ips
+ACT_OUT         := $(LUMA_SYSMODULES_OUT)/$(ACT_TITLE_ID).ips
+SSL_OUT         := $(LUMA_SYSMODULES_OUT)/$(SSL_TITLE_ID).ips
 MIIVERSE_OUT_JPN    := $(LUMA_OUT)/$(MIIVERSE_ID_JPN)
 MIIVERSE_OUT_USA    := $(LUMA_OUT)/$(MIIVERSE_ID_USA)
 MIIVERSE_OUT_EUR    := $(LUMA_OUT)/$(MIIVERSE_ID_EUR)
@@ -27,17 +28,18 @@ MIIVERSE_OUT_EUR    := $(LUMA_OUT)/$(MIIVERSE_ID_EUR)
 all:
 	@rm -rf $(OUT_FOLDER)
 
-	@mkdir -p $(3DSX_OUT_FOLDER)/$(FRIENDS_OUT) $(3DSX_OUT_FOLDER)/$(ACT_OUT)
-	@mkdir -p $(3DSX_OUT_FOLDER)/$(SSL_OUT) $(3DSX_OUT_FOLDER)/$(MIIVERSE_OUT_JPN)
-	@mkdir -p $(3DSX_OUT_FOLDER)/$(MIIVERSE_OUT_USA) $(3DSX_OUT_FOLDER)/$(MIIVERSE_OUT_EUR)
+	@mkdir -p $(3DSX_OUT_FOLDER)/$(LUMA_SYSMODULES_OUT)
+	@mkdir -p $(3DSX_OUT_FOLDER)/$(MIIVERSE_OUT_JPN)
+	@mkdir -p $(3DSX_OUT_FOLDER)/$(MIIVERSE_OUT_USA)
+	@mkdir -p $(3DSX_OUT_FOLDER)/$(MIIVERSE_OUT_EUR)
 	@mkdir -p $(3DSX_OUT_FOLDER)/$(3DS_OUT) $(CIA_OUT_FOLDER)
 	@mkdir -p $(CIA_OUT_FOLDER)/$(CIA_OUT)
 	
 	@$(MAKE) -C patches
 	
-	@cp -r patches/friends/out/* $(3DSX_OUT_FOLDER)/$(FRIENDS_OUT)
-	@cp -r patches/act/out/* $(3DSX_OUT_FOLDER)/$(ACT_OUT)
-	@cp -r patches/ssl/out/* $(3DSX_OUT_FOLDER)/$(SSL_OUT)
+	@cp -r patches/friends/out/code.ips $(3DSX_OUT_FOLDER)/$(FRIENDS_OUT)
+	@cp -r patches/act/out/code.ips $(3DSX_OUT_FOLDER)/$(ACT_OUT)
+	@cp -r patches/ssl/out/code.ips $(3DSX_OUT_FOLDER)/$(SSL_OUT)
 	@cp -r patches/miiverse/out/* $(3DSX_OUT_FOLDER)/$(MIIVERSE_OUT_JPN)
 	@cp -r patches/miiverse/out/* $(3DSX_OUT_FOLDER)/$(MIIVERSE_OUT_USA)
 	@cp -r patches/miiverse/out/* $(3DSX_OUT_FOLDER)/$(MIIVERSE_OUT_EUR)


### PR DESCRIPTION
The sysmodules patches now have to be on a different folder `/luma/sysmodules`, and with the title ID as the filename of each patch.