### PR TITLE
patches/act: Fix crash with no accounts

### DIFF
--- a/patches/act/src/main.s
+++ b/patches/act/src/main.s
@@ -8,8 +8,7 @@
 .include "src/account_url.s"
 
 ; Prevent unused accounts from being deleted on act start
-.org 0x114f8c
-  mov r0, #1
-  bx lr
+.org 0x114f98
+  b 0x114fa8
 
 .close


### PR DESCRIPTION
This ACT patch changes a function with counts the number of accounts of the system to always report 1 account. If there are no accounts, such as on a system format or on a fresh Citra instance, this would make the sysmodule try to read from non-existent data.

We replace the patch to allow the sysmodule to enter the counting loop, but only once. After finishing the loop, we jump out of it to the end and return the count.