### PR TITLE
[Important] Fix Miiverse patch misattribution and missing license

### DIFF
--- a/patches/miiverse/LICENSE
+++ b/patches/miiverse/LICENSE
@@ -1,0 +1,23 @@
+The MIT License (MIT)
+
+Copyright (c) 2018 Stary (https://github.com/Stary2001)
+Copyright (c) 2018 Sono (https://github.com/SonoSooS)
+Copyright (c) 2024 Pretendo Network Contributors (https://github.com/PretendoNetwork)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/patches/miiverse/README.md
+++ b/patches/miiverse/README.md
@@ -1,6 +1,7 @@
-# Miiverse patches for Juxtaposition
-Basically just Juxt patches that have a bit nicer looking code and building closer to how the rest of the Nimbus patches are.
+# Miiverse patches
+Based on the original patches by [Stary](https://github.com/Stary2001) and [Sono](https://github.com/SonoSooS),
+but cleaned up a bit with a Makefile closer to the rest of the Nimbus patches.
 
-To compile, you need armips, make, and flips.
+Any region decompressed Miiverse code.bin should work for building.
 
-Any decompressed Miiverse code.bin works fine.
+To compile, you need armips, make, flips, and the aforementioned Miiverse `code.bin`.


### PR DESCRIPTION
Adds the missing MIT license for Miiverse patches, and attributes the original creators of the Miiverse patches in the patch README

This also cleans up the Miiverse patch readme a bit as it wasn't looking too great in the first place.

<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

### Changes:

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

- [X] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [X] I have tested all of my changes.