### PR TITLE
fix: Create `/luma` directory when updating if it doesn't exist

### DIFF
--- a/app/source/states/MainUI.cpp
+++ b/app/source/states/MainUI.cpp
@@ -190,6 +190,7 @@ bool MainUI::drawUI(MainStruct *mainStruct, C3D_RenderTarget* top_screen, C3D_Re
 
             // If the migration has failed, don't do the update. In such case users need to contact support
             if (mainStruct->errorString[0] == 0) {
+                mkdir("/luma", 0777);
                 mkdir("/luma/sysmodules", 0777);
                 std::remove("/luma/sysmodules/0004013000003202.ips");
                 std::rename(NIMBUS_UPDATE_PATH "/0004013000003202.ips", "/luma/sysmodules/0004013000003202.ips");


### PR DESCRIPTION
### Changes:

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

Currently, Nimbus doesn't ensure that the `/luma` directory exists when installing its files during an update. On a real 3DS console this is reasonable, as directory should always exist if Nimbus is being used due to its dependence on custom firmware.

On emulators such as Azahar however, this directory doesn't exist by default. This means that if a user wishes to install Nimbus in a fresh Azahar installation, the update process will silently fail, and none of the files will be installed into their correct places, instead remaining in the `/3ds/nimbus/update` directory. The only way to work around this currently is to manually create the `/luma` directory and then re-trigger the Nimbus update. 

I haven't built and tested this change locally, but I did verify that the problem goes away after addressing an issue on Azahar's end in https://github.com/azahar-emu/azahar/pull/1506 and manually creating the `/luma` directory using the Android file manager. The change is trivial, and this exact same kind of code is used several lines down for `/luma/titles`, so testing on my end seems unnecessary.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.