### PR TITLE
Add a scam warning to the top screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ target
 
 # Publish
 *.zip
+
+# MacOS
+.DS_Store

--- a/app/source/common.cpp
+++ b/app/source/common.cpp
@@ -83,8 +83,8 @@ CFG_Region GetSystemRegion() {
 void DrawScamWarning() {
 	C2D_Text c2d_text1;
 	C2D_Text c2d_text2;
-	std::string line1 = std::format("{} is free and open-source. If you paid for the app, you", APP_TITLE);
-	std::string line2 = "have been scammed. Demand your money back";
+	std::string line1 = std::format("{} is free and open-source. If you paid to have it installed,", APP_TITLE);
+	std::string line2 = "you have been scammed. Demand your money back";
 	float size = 0.5f;
 	int offset = 6;
 	int horizontalOffset = offset;

--- a/app/source/common.cpp
+++ b/app/source/common.cpp
@@ -84,7 +84,7 @@ void DrawScamWarning() {
 	C2D_Text c2d_text1;
 	C2D_Text c2d_text2;
 	std::string line1 = std::format("{} is free and open-source. If you paid for the app, you", APP_TITLE);
-	std::string line2 = std::format("have been scammed. Demand your money back", APP_TITLE);
+	std::string line2 = "have been scammed. Demand your money back";
 	float size = 0.5f;
 	int offset = 6;
 	int horizontalOffset = offset;

--- a/app/source/common.cpp
+++ b/app/source/common.cpp
@@ -80,6 +80,29 @@ CFG_Region GetSystemRegion() {
 	return static_cast<CFG_Region>(systemRegion);
 }
 
+void DrawScamWarning() {
+	C2D_Text c2d_text1;
+	C2D_Text c2d_text2;
+	std::string line1 = std::format("{} is free and open-source. If you paid for the app, you", APP_TITLE);
+	std::string line2 = std::format("have been scammed. Demand your money back", APP_TITLE);
+	float size = 0.5f;
+	int offset = 6;
+	int horizontalOffset = offset;
+	float line2Y = offset + 10;
+	float line1Y = line2Y - GetStringHeight(size, line1.c_str());
+
+	C2D_TextBufClear(textBuf);
+
+	C2D_TextFontParse(&c2d_text1, font, textBuf, line1.c_str());
+	C2D_TextOptimize(&c2d_text1);
+
+	C2D_TextFontParse(&c2d_text2, font, textBuf, line2.c_str());
+	C2D_TextOptimize(&c2d_text2);
+
+	C2D_DrawText(&c2d_text1, C2D_WithColor | C2D_AlignLeft, horizontalOffset, line1Y, 0.5f, size, size, C2D_Color32(255, 255, 255, 0xFF));
+	C2D_DrawText(&c2d_text2, C2D_WithColor | C2D_AlignLeft, horizontalOffset, line2Y, 0.5f, size, size, C2D_Color32(255, 255, 255, 0xFF));
+}
+
 // code thats mostly by me again 
 void DrawVersionString() {
 	C2D_Text c2d_text;

--- a/app/source/common.cpp
+++ b/app/source/common.cpp
@@ -88,7 +88,7 @@ void DrawScamWarning() {
 	float size = 0.5f;
 	int offset = 6;
 	int horizontalOffset = offset;
-	float line2Y = offset + 10;
+	float line2Y = (240 + 2) - offset - GetStringHeight(size, line2.c_str());
 	float line1Y = line2Y - GetStringHeight(size, line1.c_str());
 
 	C2D_TextBufClear(textBuf);
@@ -109,16 +109,14 @@ void DrawVersionString() {
 	std::string text = std::format("{} {}.{}.{}", APP_TITLE, VERSION_MAJOR, VERSION_MINOR, VERSION_MICRO);
 	float size = 0.5f;
 	int offset = 6;
-	int bottomOffset = (240 + 2)- offset; // 3ds vertical resolution - offset, but add 2 to the vertical resolution to account for the vertical padding?
 	int horizontalOffset = 400 - offset;
-	
+
 	C2D_TextBufClear(textBuf);
-	
+
 	C2D_TextFontParse(&c2d_text, font, textBuf, text.c_str());
 	C2D_TextOptimize(&c2d_text);
 
-	C2D_DrawText(&c2d_text, C2D_WithColor | C2D_AlignRight, horizontalOffset, bottomOffset - GetStringHeight(size, text.c_str()), 0.5f, size, size, C2D_Color32(255, 255, 255, 0xFF));
-	
+	C2D_DrawText(&c2d_text, C2D_WithColor | C2D_AlignRight, horizontalOffset, offset, 0.5f, size, size, C2D_Color32(255, 255, 255, 0xFF));
 }
 
 bool GetLumaOptionByIndex(LumaConfigBitIndex index, s64 options) {

--- a/app/source/common.hpp
+++ b/app/source/common.hpp
@@ -137,6 +137,8 @@ void DrawControls();
 // this is kinda from citro2d
 CFG_Region GetSystemRegion();
 
+void DrawScamWarning();
+
 // code thats mostly by me again
 void DrawVersionString();
 

--- a/app/source/states/MainUI.cpp
+++ b/app/source/states/MainUI.cpp
@@ -345,6 +345,7 @@ bool MainUI::drawUI(MainStruct *mainStruct, C3D_RenderTarget* top_screen, C3D_Re
     }
 
     C2D_SceneBegin(top_screen);
+    DrawScamWarning();
     DrawVersionString();
     C2D_DrawSprite(&mainStruct->top);
 


### PR DESCRIPTION
Resolves #XXX

### Changes:

As discussed on Discord, certain people have started selling free homebrew apps for a premium under "homebrew modding services". This includes a person who is, effectively, selling Nimbus for upwards of $100 (as part of an "extensive modding service package", $60 more than her standard package).

We do not agree with this behavior. Selling a modding service is one thing, somewhat akin to companies who sell pre-built PCs with Windows installed. Not something we would use, but a potentially legitimate service for non-savvy users who do not feel comfortable doing the task themselves. But this person is using our name (and others) to arbitrarily charge out the ass for installing a free app under the guise of "extensive modding", when installing these apps is no more "extensive" than installing an app on your phone from the App Store thanks to UU.

Vapecord has already added a similar scam warning (https://github.com/RedShyGuy/Vapecord-ACNL-Plugin/blob/eed9d5970f9d057507cad95182d18c3fca21eaad/tools/localization/languages/en.json#L1039-L1040), so I think now is a good time to do so for us.

Vapecord does only show their warning the first time the plugin launches, but I don't think this is effective. People like the user in question here would simply launch Nimbus once to dismiss the warning. So I've decided to simply always show it. If she wants to get rid of the warning, she now has to go through the trouble of removing it by hand or using an older version (which, at some point, will break considering we will likely need to do the same kind of changes for ACNL on other games)

I will probably also reach out to NetPass after this is merged, since they are also one of the apps directly named in these scams

Also this might be a good time to take some notes from Vapecord and add translations to Nimbus? Might be better in a different PR though

Screenshot from Azahar for how the warning looks:

<img width="871" height="1022" alt="Screenshot 2026-04-15 at 6 23 50 PM" src="https://github.com/user-attachments/assets/94753c4e-5749-4a21-b328-1ad292527290" />

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.